### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM phusion/baseimage:0.9.16
+#FROM phusion/baseimage:0.9.16
+FROM phusion/baseimage:focal-1.0.0
 MAINTAINER pinion <pinion@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -15,9 +16,10 @@ RUN usermod -g 100 nobody
 # install dependencies for building cherrymusic
 #jon-severinsson's repo quit working for me :(
 #RUN add-apt-repository ppa:jon-severinsson/ffmpeg
-RUN apt-add-repository ppa:mc3man/trusty-media
+#RUN apt-add-repository ppa:mc3man/trusty-media
 RUN apt-get update -qq
-RUN apt-get -y install ffmpeg python3-cherrypy3 imagemagick python-unidecode git mpg123 faad vorbis-tools flac imagemagick python-pip lame libmp3lame0
+#RUN apt-get -y install ffmpeg python3-cherrypy3 imagemagick python-unidecode git mpg123 faad vorbis-tools flac imagemagick python-pip lame libmp3lame0
+RUN apt-get -y install ffmpeg python3-cherrypy3 imagemagick git mpg123 faad vorbis-tools flac imagemagick lame libmp3lame0 python3-pip python3.9-full
 RUN apt-get clean
 RUN pip install cherrypy
 


### PR DESCRIPTION
This should upgrade you to the new focal phusion baseimage. trusty-media is no longer needed. This could use some cleanup but it's working.